### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a single static-site product: a personal portfolio/blog built with **Astro** (with React islands, Tailwind v4, MDX). There is no backend, database, or required secrets. The Cloudflare adapter (`@astrojs/cloudflare`) is only used for production deploy.
+
+### Toolchain
+- Package manager is **Bun** (see `bun.lock` and `mise.toml` pins `bun = "latest"`). The README mentions `npm`, but use Bun.
+- Bun is preinstalled in the VM snapshot at `~/.bun/bin/bun` and symlinked to `/usr/local/bin/bun`, so it is on `PATH` for non-interactive shells.
+
+### Commands (run from repo root)
+- Install deps: `bun install`
+- Dev server: `bun run dev` — serves at `http://localhost:4321/` (note: not port 3000 as the README claims; Astro's default is 4321).
+- Type/lint check: `bunx astro check` (uses `@astrojs/check`). Existing tree reports 0 errors / 0 warnings (only a few hints).
+- Production build: `bun run build` → outputs `./dist` (also generates Open Graph images via `@resvg/resvg-js`).
+- Preview built site: `bun run preview` (requires a prior `bun run build`).
+
+### Notes / gotchas
+- `bun run build` logs `(file not created, response body was empty)` for routes that are pure redirects (e.g. `/tools/*`, `/gsoc-2020-appinventor-project-vce`). This is expected — those are configured `redirects` in `astro.config.mjs`, not real pages.
+- OG image generation reads font `.woff` files from `node_modules/@fontsource/*`, so a full `bun install` must complete before building.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up the development environment for this Astro portfolio/blog and documents it for future Cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the Bun toolchain, dev/build/check commands, the actual dev port (`4321`), and build gotchas.
- Update script for the VM: `bun install` (Bun is preinstalled in the snapshot at `~/.bun/bin/bun`, symlinked to `/usr/local/bin/bun`).

No application code was modified.

## Verification
- `bun install` — 801 packages installed
- `bunx astro check` — 0 errors, 0 warnings
- `bun run build` — 49 pages built
- `bun run dev` — serves at `http://localhost:4321/`; homepage, blog index, and a blog article verified end-to-end in the browser.

[astro_portfolio_blog_navigation.mp4](https://cursor.com/agents/bc-e932a178-59ab-4b0c-be71-453459449bff/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fastro_portfolio_blog_navigation.mp4)

[Homepage](https://cursor.com/agents/bc-e932a178-59ab-4b0c-be71-453459449bff/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_page.webp)
[Blog article](https://cursor.com/agents/bc-e932a178-59ab-4b0c-be71-453459449bff/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_article.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e932a178-59ab-4b0c-be71-453459449bff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e932a178-59ab-4b0c-be71-453459449bff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

