### PR TITLE
fix(cloudflare): stop auto-provisioning SESSION KV namespace on deploy

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config';
+import { defineConfig, sessionDrivers } from 'astro/config';
 import icon from "astro-icon";
 import tailwindcss from '@tailwindcss/vite';
 import mdx from '@astrojs/mdx';
@@ -18,6 +18,14 @@ import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 export default defineConfig({
   site: "https://pavi2410.com",
   trailingSlash: 'ignore',
+
+  // This is a fully static site that does not use Astro sessions. By default the
+  // Cloudflare adapter enables a KV-backed session driver, which makes Wrangler try
+  // to auto-provision a "website-session" KV namespace on deploy (failing once it
+  // already exists). Using the no-op driver opts out of that KV binding entirely.
+  session: {
+    driver: sessionDrivers.null(),
+  },
 
   redirects: {
     '/gsoc-2020-appinventor-project-vce': '/blog/gsoc-2020-appinventor-project-vce',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
The Cloudflare deploy (`npx wrangler versions upload`) fails at the provisioning step:

```
[@astrojs/cloudflare] Enabling sessions with Cloudflare KV with the "SESSION" KV binding.
Provisioning SESSION (KV Namespace)... Creating new KV Namespace "website-session"...
✘ [ERROR] a namespace with this account ID and title already exists [code: 10014]
Failed: error occurred while running deploy command
```

### Root cause
`@astrojs/cloudflare` enables a KV-backed session driver by default whenever no `session.driver` is configured (see `node_modules/@astrojs/cloudflare/dist/index.js`). This injects a `SESSION` KV binding **without an id** into the generated `dist/client/wrangler.json`, so Wrangler's experimental auto-provisioning tries to *create* a `website-session` namespace. Because that namespace already exists in the account, provisioning fails with code `10014`.

This site is fully static (`output: "static"`) and never uses Astro sessions (no `Astro.session` / `context.session` usage anywhere in `src/`).

## Fix
Configure the no-op session driver in `astro.config.mjs`:

```js
session: {
  driver: sessionDrivers.null(),
}
```

This sets a non-KV driver, so the adapter no longer requests a `SESSION` KV binding, and Wrangler has nothing to provision. No Cloudflare credentials or namespace id are required.

## Verification
- `bun run build` — succeeds (49 pages); the `Enabling sessions with Cloudflare KV` log no longer appears.
- Generated `dist/client/wrangler.json` now has `"kv_namespaces": []` (previously contained the `SESSION` binding that triggered provisioning).
- `bunx astro check` — 0 errors, 0 warnings.
- `bun run dev` — site still serves correctly (`/`, `/blog`, blog article all return HTTP 200).

[session_kv_fix_evidence.log](https://cursor.com/agents/bc-e932a178-59ab-4b0c-be71-453459449bff/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsession_kv_fix_evidence.log)

Note: the deploy itself can't be run from CI here (no Cloudflare credentials in the agent environment), but removing the unmanaged `SESSION` KV binding eliminates the provisioning step that was failing.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e932a178-59ab-4b0c-be71-453459449bff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e932a178-59ab-4b0c-be71-453459449bff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

